### PR TITLE
[Hugging Face integration] Make download stats work, better discoverability

### DIFF
--- a/MeshAnything/miche/encode.py
+++ b/MeshAnything/miche/encode.py
@@ -46,7 +46,8 @@ def load_model(ckpt_path="MeshAnything/miche/shapevae-256.ckpt"):
         model_config = model_config.model
 
     model = instantiate_from_config(model_config, ckpt_path=ckpt_path)
-    model = model.cuda()
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model.to(device)
     model = model.eval()
 
     return model

--- a/MeshAnything/models/meshanything_v2.py
+++ b/MeshAnything/models/meshanything_v2.py
@@ -1,13 +1,14 @@
 import torch
-import torch.nn.functional as nnf
 from torch import nn
-import random
 from transformers import AutoModelForCausalLM
 from MeshAnything.miche.encode import load_model
 from MeshAnything.models.shape_opt import ShapeOPTConfig
-from einops import repeat, reduce, rearrange, pack, unpack
+from einops import rearrange
 
-class MeshAnythingV2(nn.Module):
+from huggingface_hub import PyTorchModelHubMixin
+
+class MeshAnythingV2(nn.Module, PyTorchModelHubMixin,
+                     repo_url="https://github.com/buaacyw/MeshAnythingV2", pipeline_tag=["image-to-3d"], license="mit"):
     def __init__(self):
         super().__init__()
         self.point_encoder = load_model(ckpt_path=None)

--- a/MeshAnything/models/meshanything_v2.py
+++ b/MeshAnything/models/meshanything_v2.py
@@ -9,8 +9,9 @@ from huggingface_hub import PyTorchModelHubMixin
 
 class MeshAnythingV2(nn.Module, PyTorchModelHubMixin,
                      repo_url="https://github.com/buaacyw/MeshAnythingV2", pipeline_tag="image-to-3d", license="mit"):
-    def __init__(self):
+    def __init__(self, config=None):
         super().__init__()
+        self.config = config
         self.point_encoder = load_model(ckpt_path=None)
         self.n_discrete_size = 128
         self.max_seq_ratio = 0.70

--- a/MeshAnything/models/meshanything_v2.py
+++ b/MeshAnything/models/meshanything_v2.py
@@ -8,7 +8,7 @@ from einops import rearrange
 from huggingface_hub import PyTorchModelHubMixin
 
 class MeshAnythingV2(nn.Module, PyTorchModelHubMixin,
-                     repo_url="https://github.com/buaacyw/MeshAnythingV2", pipeline_tag=["image-to-3d"], license="mit"):
+                     repo_url="https://github.com/buaacyw/MeshAnythingV2", pipeline_tag="image-to-3d", license="mit"):
     def __init__(self):
         super().__init__()
         self.point_encoder = load_model(ckpt_path=None)

--- a/MeshAnything/models/meshanything_v2.py
+++ b/MeshAnything/models/meshanything_v2.py
@@ -9,7 +9,7 @@ from huggingface_hub import PyTorchModelHubMixin
 
 class MeshAnythingV2(nn.Module, PyTorchModelHubMixin,
                      repo_url="https://github.com/buaacyw/MeshAnythingV2", pipeline_tag="image-to-3d", license="mit"):
-    def __init__(self, config=None):
+    def __init__(self, config={}):
         super().__init__()
         self.config = config
         self.point_encoder = load_model(ckpt_path=None)


### PR DESCRIPTION
This PR leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/hub/models-uploading#upload-a-pytorch-model-using-huggingfacehub) to add `from_pretrained` and `push_to_hub` capabilities to the MeshAnythingV2 class. This automatically pushes a model card along with metadata, enforcing download stats to work as well.

The model is here: https://huggingface.co/nielsr/meshanythingv2.

cc @Wauplin any insights into why the config.json doesn't get pushed? Is this because self.config gets overridden in the init?  Might get fixed by including an empty config.json in the model repo